### PR TITLE
ajout du param de feuille de style "rawfulltextpath" et prise en compte dans Wiley

### DIFF
--- a/Stylesheets/Publishers.xsl
+++ b/Stylesheets/Publishers.xsl
@@ -11,6 +11,8 @@
     <xsl:param name="datecreation"/>
     <xsl:param name="idistex"/>
     <xsl:param name="arkistex"/>
+    <xsl:param name="rawfulltextpath"/>
+    
     <xsl:include href="Imports.xsl"/>
 
     <xsl:include href="BMJ.xsl"/>

--- a/Stylesheets/Wiley.xsl
+++ b/Stylesheets/Wiley.xsl
@@ -110,6 +110,9 @@
     <xsl:template match="component">
         <xsl:message>Wiley.xsl</xsl:message>
         <TEI>
+            <xsl:attribute name="xsi:noNamespaceSchemaLocation">
+                <xsl:text>https://istex.github.io/odd-istex/out/istex.xsd</xsl:text>
+            </xsl:attribute>
             <xsl:attribute name="xml:lang">
                 <xsl:value-of select="$codeLangue"/>
             </xsl:attribute>
@@ -422,6 +425,13 @@
                     <xsl:when test="body/section">
                         <body>
                             <xsl:apply-templates select="body" mode="bodyOnly"/>
+                        </body>
+                    </xsl:when>
+                    <xsl:when test="$rawfulltextpath">
+                        <body>
+                            <div>
+                                <p><xsl:value-of select="unparsed-text($rawfulltextpath, 'UTF-8')"/></p>
+                            </div>
                         </body>
                     </xsl:when>
                     <xsl:otherwise>

--- a/Stylesheets/Wiley.xsl
+++ b/Stylesheets/Wiley.xsl
@@ -110,9 +110,6 @@
     <xsl:template match="component">
         <xsl:message>Wiley.xsl</xsl:message>
         <TEI>
-            <xsl:attribute name="xsi:noNamespaceSchemaLocation">
-                <xsl:text>https://istex.github.io/odd-istex/out/istex.xsd</xsl:text>
-            </xsl:attribute>
             <xsl:attribute name="xml:lang">
                 <xsl:value-of select="$codeLangue"/>
             </xsl:attribute>

--- a/Stylesheets/Wiley.xsl
+++ b/Stylesheets/Wiley.xsl
@@ -427,7 +427,7 @@
                             <xsl:apply-templates select="body" mode="bodyOnly"/>
                         </body>
                     </xsl:when>
-                    <xsl:when test="$rawfulltextpath">
+                    <xsl:when test="string-length($rawfulltextpath) &gt; 0">
                         <body>
                             <div>
                                 <p><xsl:value-of select="unparsed-text($rawfulltextpath, 'UTF-8')"/></p>


### PR DESCRIPTION
ce param permet d'aller chercher le texte brut pour l'insérer dans le body si jamais le XML éditeur ne possède pas de body